### PR TITLE
Add `toplevel` git alias

### DIFF
--- a/dotfiles/git/.gitconfig
+++ b/dotfiles/git/.gitconfig
@@ -76,6 +76,9 @@
 
     # run the correct command if user types 'git git status'
     git = !exec git
+    
+    # return the root directory of this repo
+    toplevel = rev-parse --show-toplevel
 
 [credential]
     helper = cache --timeout=14400


### PR DESCRIPTION
Take it or leave it. I found this recently, added the alias, and have used it _a bunch_ since then\*. I was going to text you about it ("Pro tip: ..."), but then I was like "oh wait, I can just do a PR to his dotfiles!" :shipit: 

\*For things like `svn update $(git toplevel)` (because I'm working with SVN repos) and `git ls-files --ignored --exclude-standard $(git toplevel)` and then add a `-z` and pipe that to `xargs -0 git rm --cached` (because people aren't used to working with ignore lists and keep [inadvertently or otherwise] committing things that should be ignored (yes, set up properly in svn:global-ignores - they just added ignored stuff because... [reasons]. - it's a learning process; they're growing...))